### PR TITLE
Fix For Plunger not starting from Home

### DIFF
--- a/mcu1/relayModule_v2.h
+++ b/mcu1/relayModule_v2.h
@@ -21,9 +21,9 @@
 //10mm for mtr screws
 #define LEAD_SCREW_PITCH 10  /*!< Lead screw pitch is 12.0 mm, i.e when we rotate it by 360 degree then the linear travel will be 8.0 mm in a direction */
 #define HOME_SENSE_VALUE LOW //1 for PNP(LED glows when sensed, alway high)   //0 for NPN (LED off when sensed, alway low)
-#define extra_exhale_travel 0.0
-#define power_on_home_travel 100.0 
-#define Start_home_travel 100.0 
+#define extra_exhale_travel 20.0
+#define power_on_home_travel 200.0 
+#define Start_home_travel 200.0 
 volatile int Home_attempt_count = 0;
 volatile int stop_n_return_pulse_count = 0;
 

--- a/mcu2/lcd_display/ctrl_display.cpp
+++ b/mcu2/lcd_display/ctrl_display.cpp
@@ -904,10 +904,10 @@ void displayManager::aboutScreen(RT_Events_T eRTState)
   lcd.setCursor(1, 1);
   lcd.write("Device   : BMV");
   lcd.setCursor(1, 2);
-  lcd.write("Serial No: TW0002");
+  lcd.write("Serial No: TW000X");
   lcd.setCursor(1, 3);
 
-  lcd.write("Version  : V3.02");
+  lcd.write("Version  : V3.03");
 
   if (eRTState == RT_BT_PRESS)
   {


### PR DESCRIPTION
The travel distance for the plunger in both the directions is set to stroke length.

There was a slight error that was accumulated overtime and the stroke was not starting from home in the next inhale cycle.

Added an extra travel distance to exhale cycle to make sure we move the plunger back to home without accumulating any error.

A more permanent fix would be to sense home at the beginning of the inhale cycle and at the end of the exhale cycle.